### PR TITLE
[python-lambda] Fix timeout decortor signal thread issue

### DIFF
--- a/misc/python/python-lambda/CHANGELOG.md
+++ b/misc/python/python-lambda/CHANGELOG.md
@@ -1,2 +1,5 @@
 # 1.0.0
 - Updated frinx-python-sdk to version ^1.1
+
+# 1.0.1
+- Fix timeout decorator signal thread issue

--- a/misc/python/python-lambda/frinx_worker/python_lambda/__init__.py
+++ b/misc/python/python-lambda/frinx_worker/python_lambda/__init__.py
@@ -46,7 +46,7 @@ class PythonLambda(WorkerImpl):
         cls.VISITOR.visit(ast.parse(code))
 
     @staticmethod
-    @timeout(5)  # type: ignore[misc]
+    @timeout(5, use_signals=False)  # type: ignore[misc]
     def _process_code(code: str, worker_inputs: DictAny) -> DictAny:
         ex_locals: dict[str, Any] = {"worker_input": worker_inputs}
         exec(code, None, ex_locals)

--- a/misc/python/python-lambda/pyproject.toml
+++ b/misc/python/python-lambda/pyproject.toml
@@ -18,7 +18,7 @@ packages = [{ include = "frinx_worker" }]
 name = "frinx-python-lambda"
 description = "Conductor Python Lambda worker for Frinx Machine"
 authors = ["Jozef Volak <jozef.volak@elisapolystar.com>"]
-version = "0.0.0"
+version = "1.0.1"
 readme = ["README.md", "CHANGELOG.md"]
 keywords = ["frinx-machine", "python-lambda", "worker"]
 license = "Apache 2.0"


### PR DESCRIPTION
#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Title of the PR starts with chart name (e.g. `[inventory]`)
- [ ] Update package version in principles of semantic versioning
- [ ] Update CHANGELOG.md
