### PR TITLE
FR-144 Bumped version of frinx-services-python-api to 1.1.1

### DIFF
--- a/uniconfig/python/CHANGELOG.md
+++ b/uniconfig/python/CHANGELOG.md
@@ -28,3 +28,6 @@
 # 2.2.0
 - Support gNMI installation parameters
 - Implemented worker: update-install-parameters
+
+# 2.2.1
+- Used fixed version of frinx-services-python-api v1.1.1 - fixed discovery RPC model.

--- a/uniconfig/python/poetry.lock
+++ b/uniconfig/python/poetry.lock
@@ -306,7 +306,7 @@ websockets = ">=12,<13"
 
 [[package]]
 name = "frinx-uniconfig-api"
-version = "1.1.0"
+version = "1.1.1"
 description = "Python SDK for Frinx Machine Workflow Manager"
 optional = false
 python-versions = "^3.8"
@@ -319,8 +319,8 @@ pydantic = "^2"
 [package.source]
 type = "git"
 url = "https://github.com/FRINXio/frinx-services-python-api.git"
-reference = "frinx-uniconfig-api_v1.1.0"
-resolved_reference = "db7052b056ab0cdd979cefdccb66a0a616df742d"
+reference = "frinx-uniconfig-api_v1.1.1"
+resolved_reference = "317fc3f7d84ae03de027d5869dcf24d36cbac66c"
 subdirectory = "uniconfig/python"
 
 [[package]]
@@ -1121,4 +1121,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "cf8a7e5623e6dfa283a5685eca4894e75b89e783a24b92308d842e9d08cd6614"
+content-hash = "982ac883edc36faf39be8e9173ba86b9330a3bb7e636edda059a1d11194d57cb"

--- a/uniconfig/python/pyproject.toml
+++ b/uniconfig/python/pyproject.toml
@@ -7,7 +7,7 @@ python = "^3.10"
 pydantic = "^2"
 requests = "^2.31.0"
 frinx-python-sdk = "^2"
-frinx-uniconfig-api = { git = "https://github.com/FRINXio/frinx-services-python-api.git", tag = "frinx-uniconfig-api_v1.1.0", subdirectory = "uniconfig/python" }
+frinx-uniconfig-api = { git = "https://github.com/FRINXio/frinx-services-python-api.git", tag = "frinx-uniconfig-api_v1.1.1", subdirectory = "uniconfig/python" }
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0"
@@ -21,7 +21,7 @@ packages = [{ include = "frinx_worker" }]
 name = "frinx-uniconfig-worker"
 description = "Conductor worker for Frinx Uniconfig"
 authors = ["Jozef Volak <jozef.volak@elisapolystar.com>"]
-version = "2.2.0"
+version = "2.2.1"
 readme = ["README.md", "CHANGELOG.md", "RELEASE.md"]
 keywords = ["frinx-machine", "uniconfig", "worker"]
 license = "Apache 2.0"


### PR DESCRIPTION
- It contains fixed generated discovery RPC model.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Title of the PR starts with chart name (e.g. `[inventory]`)
- [ ] Update package version in principles of semantic versioning
- [ ] Update CHANGELOG.md
