### PR TITLE
[FR-247] Fix parsing of 'uniconfig_server_id' cookie (CreateTransaction)

### DIFF
--- a/uniconfig/python/CHANGELOG.md
+++ b/uniconfig/python/CHANGELOG.md
@@ -31,3 +31,7 @@
 
 # 2.2.1
 - Used fixed version of frinx-services-python-api v1.1.1 - fixed discovery RPC model.
+
+# 2.2.2
+- Fixed CreateTransaction worker - 'uniconfig_server_id' is optional cookie that
+  is appended by load-balancer (LB). In the deployment without LB, it is not set.

--- a/uniconfig/python/frinx_worker/uniconfig/uniconfig_manager.py
+++ b/uniconfig/python/frinx_worker/uniconfig/uniconfig_manager.py
@@ -60,7 +60,7 @@ class UniconfigManager(ServiceWorkersImpl):
                 status=TaskResultStatus.COMPLETED,
                 output=self.WorkerOutput(
                     transaction_id=response.cookies["UNICONFIGTXID"],
-                    uniconfig_server_id=response.cookies["uniconfig_server_id"],
+                    uniconfig_server_id=response.cookies.get("uniconfig_server_id", None),
                     uniconfig_url_base=worker_input.uniconfig_url_base,
                 ),
             )

--- a/uniconfig/python/pyproject.toml
+++ b/uniconfig/python/pyproject.toml
@@ -21,7 +21,7 @@ packages = [{ include = "frinx_worker" }]
 name = "frinx-uniconfig-worker"
 description = "Conductor worker for Frinx Uniconfig"
 authors = ["Jozef Volak <jozef.volak@elisapolystar.com>"]
-version = "2.2.1"
+version = "2.2.2"
 readme = ["README.md", "CHANGELOG.md", "RELEASE.md"]
 keywords = ["frinx-machine", "uniconfig", "worker"]
 license = "Apache 2.0"


### PR DESCRIPTION
- Fixed CreateTransaction worker - 'uniconfig_server_id' is optional cookie that
  is appended by load-balancer (LB). In the deployment without LB, it is not set.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Title of the PR starts with chart name (e.g. `[inventory]`)
- [ ] Update package version in principles of semantic versioning
- [ ] Update CHANGELOG.md
