### PR TITLE
Fix 'close_transactions' worker input

### DIFF
--- a/uniconfig/python/CHANGELOG.md
+++ b/uniconfig/python/CHANGELOG.md
@@ -51,3 +51,6 @@
 
 # 2.3.4
 - Device Discovery RPC workaround caused by choice-nodes in UniConfig Yang models.
+
+# 2.3.5
+- Fix handling of null or empty input in the 'close_transactions' worker.

--- a/uniconfig/python/frinx_worker/uniconfig/transaction_helpers.py
+++ b/uniconfig/python/frinx_worker/uniconfig/transaction_helpers.py
@@ -124,7 +124,8 @@ class TransactionHelpers(ServiceWorkersImpl):
 
         class WorkerInput(TaskInput):
             uniconfig_transactions: list[UniconfigTransactionContext] = Field(
-                description="List of UniConfig transactions to be closed by this worker."
+                description="List of UniConfig transactions to be closed by this worker.",
+                default=[]
             )
 
         class WorkerOutput(TaskOutput):

--- a/uniconfig/python/pyproject.toml
+++ b/uniconfig/python/pyproject.toml
@@ -21,7 +21,7 @@ packages = [{ include = "frinx_worker" }]
 name = "frinx-uniconfig-worker"
 description = "Conductor worker for Frinx Uniconfig"
 authors = ["Jozef Volak <jozef.volak@elisapolystar.com>"]
-version = "2.3.4"
+version = "2.3.5"
 readme = ["README.md", "CHANGELOG.md", "RELEASE.md"]
 keywords = ["frinx-machine", "uniconfig", "worker"]
 license = "Apache 2.0"


### PR DESCRIPTION
- Fix handling of null or empty input in the 'close_transactions'
  worker by setting default value to empty list.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Title of the PR starts with chart name (e.g. `[inventory]`)
- [ ] Update package version in principles of semantic versioning
- [ ] Update CHANGELOG.md
