### PR TITLE
Fix connection-manager and discovery workers

### DIFF
--- a/uniconfig/python/CHANGELOG.md
+++ b/uniconfig/python/CHANGELOG.md
@@ -59,3 +59,8 @@
 - Upgrade UniConfig API to v2.0.0 (server version 7.0.0).
 - Removed temporary workaround related to unwrapping of choice nodes in the Device Discovery and Install Node RPC.
 - Integrated new key-value escaping mechanism into workers.
+
+# 3.0.1
+- Fix connection-manager and discovery workers.
+- Connection-manager - Pydantic cannot correctly handle combination of aliases and unions.
+- Discovery - Fixed renamed elements.

--- a/uniconfig/python/pyproject.toml
+++ b/uniconfig/python/pyproject.toml
@@ -21,7 +21,7 @@ packages = [{ include = "frinx_worker" }]
 name = "frinx-uniconfig-worker"
 description = "Conductor worker for Frinx Uniconfig"
 authors = ["Jozef Volak <jozef.volak@elisapolystar.com>"]
-version = "3.0.0"
+version = "3.0.1"
 readme = ["README.md", "CHANGELOG.md", "RELEASE.md"]
 keywords = ["frinx-machine", "uniconfig", "worker"]
 license = "Apache 2.0"

--- a/uniconfig/python/tests/test_device_discovery.py
+++ b/uniconfig/python/tests/test_device_discovery.py
@@ -18,9 +18,9 @@ from frinx_worker.uniconfig.device_discovery import DeviceDiscoveryWorkers
 class TestDeviceDiscovery(unittest.TestCase):
     def test_tcp_validation_list(self) -> None:
         tcp_port = "21,22,23"
-        expected = [TcpPortItem(type_of_port=DeviceDiscoveryTypeOfPortModel(port=21)),
-                    TcpPortItem(type_of_port=DeviceDiscoveryTypeOfPortModel(port=22)),
-                    TcpPortItem(type_of_port=DeviceDiscoveryTypeOfPortModel(port=23))
+        expected = [TcpPortItem(device_discovery_type_of_port=DeviceDiscoveryTypeOfPortModel(port=21)),
+                    TcpPortItem(device_discovery_type_of_port=DeviceDiscoveryTypeOfPortModel(port=22)),
+                    TcpPortItem(device_discovery_type_of_port=DeviceDiscoveryTypeOfPortModel(port=23))
                     ]
         result = DeviceDiscoveryWorkers.DeviceDiscoveryWorker.WorkerInput.validate_tcp(tcp_port=tcp_port)  # type: ignore
         assert expected == result
@@ -28,9 +28,9 @@ class TestDeviceDiscovery(unittest.TestCase):
 
     def test_tcp_validation_range(self) -> None:
         tcp_port = "21-23"
-        expected = [TcpPortItem(type_of_port=DeviceDiscoveryTypeOfPortModel(port=21)),
-                    TcpPortItem(type_of_port=DeviceDiscoveryTypeOfPortModel(port=22)),
-                    TcpPortItem(type_of_port=DeviceDiscoveryTypeOfPortModel(port=23))
+        expected = [TcpPortItem(device_discovery_type_of_port=DeviceDiscoveryTypeOfPortModel(port=21)),
+                    TcpPortItem(device_discovery_type_of_port=DeviceDiscoveryTypeOfPortModel(port=22)),
+                    TcpPortItem(device_discovery_type_of_port=DeviceDiscoveryTypeOfPortModel(port=23))
                     ]
         result = DeviceDiscoveryWorkers.DeviceDiscoveryWorker.WorkerInput.validate_tcp(tcp_port=tcp_port)  # type: ignore
         assert expected == result
@@ -38,10 +38,10 @@ class TestDeviceDiscovery(unittest.TestCase):
 
     def test_tcp_validation_list_range(self) -> None:
         tcp_port = "21-23,25"
-        expected = [TcpPortItem(type_of_port=DeviceDiscoveryTypeOfPortModel(port=21)),
-                    TcpPortItem(type_of_port=DeviceDiscoveryTypeOfPortModel(port=22)),
-                    TcpPortItem(type_of_port=DeviceDiscoveryTypeOfPortModel(port=23)),
-                    TcpPortItem(type_of_port=DeviceDiscoveryTypeOfPortModel(port=25))
+        expected = [TcpPortItem(device_discovery_type_of_port=DeviceDiscoveryTypeOfPortModel(port=21)),
+                    TcpPortItem(device_discovery_type_of_port=DeviceDiscoveryTypeOfPortModel(port=22)),
+                    TcpPortItem(device_discovery_type_of_port=DeviceDiscoveryTypeOfPortModel(port=23)),
+                    TcpPortItem(device_discovery_type_of_port=DeviceDiscoveryTypeOfPortModel(port=25))
                     ]
         result = DeviceDiscoveryWorkers.DeviceDiscoveryWorker.WorkerInput.validate_tcp(tcp_port=tcp_port)  # type: ignore
         assert expected == result
@@ -49,9 +49,9 @@ class TestDeviceDiscovery(unittest.TestCase):
 
     def test_udp_validation_list(self) -> None:
         udp_port = "21,22,23"
-        expected = [UdpPortItem(type_of_port=DeviceDiscoveryTypeOfPortModel2(port=21)),
-                    UdpPortItem(type_of_port=DeviceDiscoveryTypeOfPortModel2(port=22)),
-                    UdpPortItem(type_of_port=DeviceDiscoveryTypeOfPortModel2(port=23))
+        expected = [UdpPortItem(device_discovery_type_of_port=DeviceDiscoveryTypeOfPortModel2(port=21)),
+                    UdpPortItem(device_discovery_type_of_port=DeviceDiscoveryTypeOfPortModel2(port=22)),
+                    UdpPortItem(device_discovery_type_of_port=DeviceDiscoveryTypeOfPortModel2(port=23))
                     ]
         result = DeviceDiscoveryWorkers.DeviceDiscoveryWorker.WorkerInput.validate_udp(udp_port=udp_port)  # type: ignore
         assert expected == result
@@ -59,9 +59,9 @@ class TestDeviceDiscovery(unittest.TestCase):
 
     def test_udp_validation_range(self) -> None:
         udp_port = "21-23"
-        expected = [UdpPortItem(type_of_port=DeviceDiscoveryTypeOfPortModel2(port=21)),
-                    UdpPortItem(type_of_port=DeviceDiscoveryTypeOfPortModel2(port=22)),
-                    UdpPortItem(type_of_port=DeviceDiscoveryTypeOfPortModel2(port=23))
+        expected = [UdpPortItem(device_discovery_type_of_port=DeviceDiscoveryTypeOfPortModel2(port=21)),
+                    UdpPortItem(device_discovery_type_of_port=DeviceDiscoveryTypeOfPortModel2(port=22)),
+                    UdpPortItem(device_discovery_type_of_port=DeviceDiscoveryTypeOfPortModel2(port=23))
                     ]
         result = DeviceDiscoveryWorkers.DeviceDiscoveryWorker.WorkerInput.validate_udp(udp_port=udp_port)  # type: ignore
         assert expected == result
@@ -69,10 +69,10 @@ class TestDeviceDiscovery(unittest.TestCase):
 
     def test_udp_validation_list_range(self) -> None:
         udp_port = "21-23,25"
-        expected = [UdpPortItem(type_of_port=DeviceDiscoveryTypeOfPortModel2(port=21)),
-                    UdpPortItem(type_of_port=DeviceDiscoveryTypeOfPortModel2(port=22)),
-                    UdpPortItem(type_of_port=DeviceDiscoveryTypeOfPortModel2(port=23)),
-                    UdpPortItem(type_of_port=DeviceDiscoveryTypeOfPortModel2(port=25))
+        expected = [UdpPortItem(device_discovery_type_of_port=DeviceDiscoveryTypeOfPortModel2(port=21)),
+                    UdpPortItem(device_discovery_type_of_port=DeviceDiscoveryTypeOfPortModel2(port=22)),
+                    UdpPortItem(device_discovery_type_of_port=DeviceDiscoveryTypeOfPortModel2(port=23)),
+                    UdpPortItem(device_discovery_type_of_port=DeviceDiscoveryTypeOfPortModel2(port=25))
                     ]
         result = DeviceDiscoveryWorkers.DeviceDiscoveryWorker.WorkerInput.validate_udp(udp_port=udp_port)  # type: ignore
         assert expected == result
@@ -81,7 +81,7 @@ class TestDeviceDiscovery(unittest.TestCase):
     def test_validate_ip_single_ip_v4(self) -> None:
         ip = "192.168.0.59"
         expected = [
-            Address(type_of_address=DeviceDiscoveryTypeOfAddressModel(ip_address="192.168.0.59"))
+            Address(device_discovery_type_of_address=DeviceDiscoveryTypeOfAddressModel(ip_address="192.168.0.59"))
         ]
         result = DeviceDiscoveryWorkers.DeviceDiscoveryWorker.WorkerInput.validate_ip(ip=ip)  # type: ignore
         assert expected == result
@@ -90,7 +90,7 @@ class TestDeviceDiscovery(unittest.TestCase):
     def test_validate_ip_range_ip_v4(self) -> None:
         ip = "192.168.0.59-192.168.0.90"
         expected = [
-            Address(type_of_address=DeviceDiscoveryTypeOfAddressModel1(
+            Address(device_discovery_type_of_address=DeviceDiscoveryTypeOfAddressModel1(
                                 start_ipv4_address="192.168.0.59",
                                 end_ipv4_address="192.168.0.90",
                             )
@@ -103,7 +103,7 @@ class TestDeviceDiscovery(unittest.TestCase):
     def test_validate_ip_network_v4(self) -> None:
         ip = "192.168.0.0/24"
         expected = [
-            Address(type_of_address=DeviceDiscoveryTypeOfAddressModel3(network="192.168.0.0/24"))
+            Address(device_discovery_type_of_address=DeviceDiscoveryTypeOfAddressModel3(network="192.168.0.0/24"))
         ]
         result = DeviceDiscoveryWorkers.DeviceDiscoveryWorker.WorkerInput.validate_ip(ip=ip)  # type: ignore
         assert expected == result
@@ -112,7 +112,7 @@ class TestDeviceDiscovery(unittest.TestCase):
     def test_validate_ip_single_ip_v6(self) -> None:
         ip = "0000:0000:0000:0000:0000:ffff:c0a8:003b"
         expected = [
-            Address(type_of_address=DeviceDiscoveryTypeOfAddressModel(ip_address="::ffff:c0a8:3b"))
+            Address(device_discovery_type_of_address=DeviceDiscoveryTypeOfAddressModel(ip_address="::ffff:c0a8:3b"))
         ]
         result = DeviceDiscoveryWorkers.DeviceDiscoveryWorker.WorkerInput.validate_ip(ip=ip)  # type: ignore
         assert expected == result
@@ -120,7 +120,7 @@ class TestDeviceDiscovery(unittest.TestCase):
 
         ip = "::ffff:c0a8:3b"
         expected = [
-            Address(type_of_address=DeviceDiscoveryTypeOfAddressModel(ip_address="::ffff:c0a8:3b"))
+            Address(device_discovery_type_of_address=DeviceDiscoveryTypeOfAddressModel(ip_address="::ffff:c0a8:3b"))
         ]
         result = DeviceDiscoveryWorkers.DeviceDiscoveryWorker.WorkerInput.validate_ip(ip=ip)  # type: ignore
         assert expected == result
@@ -130,7 +130,7 @@ class TestDeviceDiscovery(unittest.TestCase):
         ip = "0000:0000:0000:0000:0000:ffff:c0a8:003b-0000:0000:0000:0000:0000:ffff:c0a8:005a"
         expected = [
             Address(
-                type_of_address=DeviceDiscoveryTypeOfAddressModel2(
+                device_discovery_type_of_address=DeviceDiscoveryTypeOfAddressModel2(
                     start_ipv6_address="::ffff:c0a8:3b",
                     end_ipv6_address="::ffff:c0a8:5a"
                 )
@@ -143,7 +143,7 @@ class TestDeviceDiscovery(unittest.TestCase):
         ip = "::ffff:c0a8:3b-::ffff:c0a8:5a"
         expected = [
             Address(
-                type_of_address=DeviceDiscoveryTypeOfAddressModel2(
+                device_discovery_type_of_address=DeviceDiscoveryTypeOfAddressModel2(
                     start_ipv6_address="::ffff:c0a8:3b",
                     end_ipv6_address="::ffff:c0a8:5a"
                 )
@@ -156,7 +156,7 @@ class TestDeviceDiscovery(unittest.TestCase):
     def test_validate_ip_network_v6(self) -> None:
         ip = "::ffff:c0a8:0/128"
         expected = [
-            Address(type_of_address=DeviceDiscoveryTypeOfAddressModel3(network="::ffff:c0a8:0/128"))
+            Address(device_discovery_type_of_address=DeviceDiscoveryTypeOfAddressModel3(network="::ffff:c0a8:0/128"))
         ]
         result = DeviceDiscoveryWorkers.DeviceDiscoveryWorker.WorkerInput.validate_ip(ip)  # type: ignore
         assert expected == result


### PR DESCRIPTION
- Connection-manager - Pydantic cannot correctly handle combination of aliases and unions.
- Discovery - Fixed renamed elements.

#### Checklist
<!-- [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Title of the PR starts with chart name (e.g. `[inventory]`)
- [ ] Update package version in principles of semantic versioning
- [ ] Update CHANGELOG.md
